### PR TITLE
bump: goreleaser

### DIFF
--- a/ci-goreleaser/Dockerfile
+++ b/ci-goreleaser/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.10.1
 
 LABEL maintainer="bjorn.erik.pedersen@gmail.com"
 
-ENV GORELEASER_VERSION=0.34.2
+ENV GORELEASER_VERSION=0.79.0
 ENV GORELEASER_SHA=013b6289cff41b8afca638007a727170efc8d61469405e2a5d30edf1343e5b68
 
 ENV GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz
@@ -26,9 +26,8 @@ RUN  wget ${GORELEASER_DOWNLOAD_URL}; \
 			tar -xzf $MAGE_DOWNLOAD_FILE -C /usr/bin/ mage; \
 			rm $MAGE_DOWNLOAD_FILE; \
 			apt-get update; \
-			apt-get install -y nano autoconf libtool ruby ruby-dev ruby-bundler; \
-		  	rm -rf /var/lib/apt/lists/*; \
-		  	gem install fpm;
+			apt-get install -y nano autoconf libtool; \
+		  	rm -rf /var/lib/apt/lists/*;
 
 CMD ["goreleaser", "-v"]
 

--- a/ci-goreleaser/README.md
+++ b/ci-goreleaser/README.md
@@ -2,8 +2,8 @@ The version represents the Goreleaser version + a counter.
 
 See https://github.com/goreleaser/goreleaser/releases
 
-So is the Goreleaser version is `0.30.5` and this is the first version based on that:
- 
+So if the Goreleaser version is `0.30.5` and this is the first version based on that:
+
 ```bash
 version=0.30.5-1 make install
 ```


### PR DESCRIPTION
not sure if nano, autoconf and libtool are required... I think we could probably remove them...

if you want to build rpms using goreleaser, we also need to install rpmbuild... since there aren't official rpm packages for hugo and it wasn't being installed before, I'm assuming you don't do that at all

refs https://github.com/gohugoio/hugo/issues/4432